### PR TITLE
Add spinner components

### DIFF
--- a/packages/frontend/src/auth/protected-route.tsx
+++ b/packages/frontend/src/auth/protected-route.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useAuth } from "./auth-provider";
 import { Navigate } from "react-router-dom";
 import { Spinner } from "react-bootstrap";
+import FullScreenSpinner from "../components/full-screen-spinner";
 
 export const ProtectedRoute: React.FunctionComponent<
   React.PropsWithChildren
@@ -9,7 +10,7 @@ export const ProtectedRoute: React.FunctionComponent<
   const { user, loading } = useAuth();
 
   return loading ? (
-    <Spinner />
+    <FullScreenSpinner />
   ) : user.name ? (
     <>{children}</>
   ) : (

--- a/packages/frontend/src/auth/protected-route.tsx
+++ b/packages/frontend/src/auth/protected-route.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useAuth } from "./auth-provider";
 import { Navigate } from "react-router-dom";
-import { Spinner } from "react-bootstrap";
 import FullScreenSpinner from "../components/full-screen-spinner";
 
 export const ProtectedRoute: React.FunctionComponent<

--- a/packages/frontend/src/components/component-centered-spinner.tsx
+++ b/packages/frontend/src/components/component-centered-spinner.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Spinner } from "react-bootstrap";
+
+export default function ComponentCenteredSpinner() {
+  return (
+    <div className="d-flex justify-content-center">
+      <Spinner animation="border" role="status" variant="secondary">
+        <span className="visually-hidden">Loading...</span>
+      </Spinner>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/full-screen-spinner.tsx
+++ b/packages/frontend/src/components/full-screen-spinner.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { Spinner } from "react-bootstrap";
+
+// make spinner full screen and greyed out
+export default function FullScreenSpinner() {
+  return (
+    <div className="position-absolute top-0 start-0 d-flex justify-content-center align-items-center vh-100 vw-100 bg-light bg-opacity-50 z-3">
+      <Spinner animation="border" role="status" variant="secondary">
+        <span className="visually-hidden">Loading...</span>
+      </Spinner>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/search-bar.tsx
+++ b/packages/frontend/src/components/search-bar.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Button, Container, Form, Spinner } from "react-bootstrap";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { Song } from "../views/view-playlist";
+import ComponentCenteredSpinner from "./component-centered-spinner";
 
 interface SearchBarProps {
   onSongFetched: (song: Song) => void;
@@ -44,7 +45,7 @@ function SearchBar(props: SearchBarProps) {
   };
 
   if (loading) {
-    return <Spinner />;
+    return <ComponentCenteredSpinner />;
   }
 
   return (

--- a/packages/frontend/src/components/search-bar.tsx
+++ b/packages/frontend/src/components/search-bar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, Container, Form, Spinner } from "react-bootstrap";
+import { Button, Container, Form } from "react-bootstrap";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { Song } from "../views/view-playlist";
 import ComponentCenteredSpinner from "./component-centered-spinner";

--- a/packages/frontend/src/views/home.tsx
+++ b/packages/frontend/src/views/home.tsx
@@ -2,9 +2,14 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { Button, Container } from "react-bootstrap";
 import { useAuth } from "../auth/auth-provider";
+import FullScreenSpinner from "../components/full-screen-spinner";
 
 export default function Home() {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return <FullScreenSpinner />;
+  }
 
   return (
     <Container>

--- a/packages/frontend/src/views/playlists.tsx
+++ b/packages/frontend/src/views/playlists.tsx
@@ -4,6 +4,7 @@ import PlaylistCard from "../components/playlist-card";
 import AddPlaylistCard from "../components/add-playlist-card";
 import { useAuth } from "../auth/auth-provider";
 import { BackLink } from "../components/back-link";
+import FullScreenSpinner from "../components/full-screen-spinner";
 
 export interface Playlist {
   _id: string;
@@ -77,7 +78,7 @@ export default function Playlists() {
   };
 
   if (loading) {
-    return <Spinner />;
+    return <FullScreenSpinner />;
   }
 
   return (

--- a/packages/frontend/src/views/playlists.tsx
+++ b/packages/frontend/src/views/playlists.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { CardGroup, Container, Spinner } from "react-bootstrap";
+import { CardGroup, Container } from "react-bootstrap";
 import PlaylistCard from "../components/playlist-card";
 import AddPlaylistCard from "../components/add-playlist-card";
 import { useAuth } from "../auth/auth-provider";

--- a/packages/frontend/src/views/view-playlist.tsx
+++ b/packages/frontend/src/views/view-playlist.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Container, Form, Button, Spinner } from "react-bootstrap";
+import { Container, Form, Button } from "react-bootstrap";
 import { useForm, SubmitHandler } from "react-hook-form";
 import SearchBar from "../components/search-bar";
 import SongCard from "../components/song-card";

--- a/packages/frontend/src/views/view-playlist.tsx
+++ b/packages/frontend/src/views/view-playlist.tsx
@@ -8,6 +8,7 @@ import { useAuth } from "../auth/auth-provider";
 import { Playlist } from "./playlists";
 import { useParams } from "react-router-dom";
 import { BackLink } from "../components/back-link";
+import FullScreenSpinner from "../components/full-screen-spinner";
 
 export interface Song {
   _id: string;
@@ -164,7 +165,7 @@ export default function ViewPlaylist() {
   };
 
   if (loading) {
-    return <Spinner />;
+    return <FullScreenSpinner />;
   }
 
   return (


### PR DESCRIPTION
Closes #97 

### Add spinner components ###

#### Changes ####

- Added full-screen spinner component for full-page loading states
- Added component-centered spinner component for component-specific loading states
- Added full-screen spinner to homepage

#### Visual Aid ####

![image](https://github.com/ryanhu021/csc307-team-project/assets/62446401/11e533e8-9212-4627-8b75-806a71cf6b08)

#### Testing ####

- `npm start`